### PR TITLE
Fixed an issue with bulk editing of posts

### DIFF
--- a/tag-pages.php
+++ b/tag-pages.php
@@ -50,7 +50,7 @@ if( ! function_exists('tagpages_register_taxonomy') ){
 if( ! function_exists('tagpages_display_tagged_pages_archive') ){
     function tagpages_display_tagged_pages_archive(&$query)
     {
-        if ( $query->is_archive && $query->is_tag ) {
+        if ( !is_admin() && $query->is_archive && $query->is_tag ) {
             $q = &$query->query_vars;
             $q['post_type'] = 'any';
         }


### PR DESCRIPTION
The "tagpages_display_tagged_pages_archive" function (which is hooked into "pre_get_posts") previously didn't check whether the query was front end or back end. This led to unexpercted behaviour when bulk editing posts in the WordPress admin.

Steps to reproduce:
- With this plugin activated, go to the admin's "Posts" screen.
- Find a post with tags and click one that has at least two associated posts.
- Select multiple posts from the filtered list, and bulk edit them.
- When applying the changes, an error message wil apear ("invalid post type").

The error screen's URL wil have a GET parameter "post_type=any". Manually removing this parameter will fix the issue.

This fix resolves the problem by not modifying the query if it is made from WP's back end.
